### PR TITLE
Fix ugly headers.headers pattern in template_sender

### DIFF
--- a/lua/taal/template_sender.lua
+++ b/lua/taal/template_sender.lua
@@ -33,7 +33,7 @@ return function(post, response_writer, timeout)
     log.fmt_trace("posting with endpoint=%s, body=%s, extra_opts=%s", endpoint, body, extra_opts)
 
     local opts = {
-      headers = headers.headers, -- TODO: ugly
+      headers = headers,
       body = body,
     }
 
@@ -52,7 +52,7 @@ return function(post, response_writer, timeout)
     local adapter = adapter_model.adapter
 
     local endpoint = adapter:endpoint(adapter_model.model)
-    local headers = adapter.post_headers()
+    local headers = adapter.post_headers().headers
 
     local adapter_template = adapter.template(template, adapter_model.model)
     local body_content = format_template(adapter_template, user_input)
@@ -96,7 +96,7 @@ return function(post, response_writer, timeout)
     local adapter = adapter_model.adapter
 
     local endpoint = adapter:endpoint(adapter_model.model, true)
-    local headers = adapter.post_headers()
+    local headers = adapter.post_headers().headers
 
     local adapter_template = adapter.template_stream(template, adapter_model.model)
     local body_content = format_template(adapter_template, user_input)

--- a/lua/taal/template_sender.lua
+++ b/lua/taal/template_sender.lua
@@ -52,7 +52,8 @@ return function(post, response_writer, timeout)
     local adapter = adapter_model.adapter
 
     local endpoint = adapter:endpoint(adapter_model.model)
-    local headers = adapter.post_headers().headers
+    local post_headers_result = adapter.post_headers()
+    local headers = post_headers_result.headers
 
     local adapter_template = adapter.template(template, adapter_model.model)
     local body_content = format_template(adapter_template, user_input)
@@ -96,7 +97,8 @@ return function(post, response_writer, timeout)
     local adapter = adapter_model.adapter
 
     local endpoint = adapter:endpoint(adapter_model.model, true)
-    local headers = adapter.post_headers().headers
+    local post_headers_result = adapter.post_headers()
+    local headers = post_headers_result.headers
 
     local adapter_template = adapter.template_stream(template, adapter_model.model)
     local body_content = format_template(adapter_template, user_input)


### PR DESCRIPTION
The adapter.post_headers() returns { headers = {...} }, but we were storing it in a variable named 'headers' and then accessing headers.headers, which was confusing.

Now we extract the actual headers immediately when calling post_headers(), making the code clearer and removing the TODO comment.